### PR TITLE
Run pip workflow for every py version after pypi publish

### DIFF
--- a/.github/workflows/pip-test.yml
+++ b/.github/workflows/pip-test.yml
@@ -1,6 +1,9 @@
 name: Check pip install
 
-on: [push]
+on:
+  workflow_run:
+    workflows: ["Upload Python Package"]
+    types: [completed]
 
 env:
   PACKAGE_NAME: bach_generator
@@ -13,10 +16,10 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: ${{ matrix.python-version }}
       - name: Install pypi package
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Added workflow testing `pip install bach_generator & python -m bach_generator -h` as a form of pip install smoke test to be run after every pypi publish.
- Modified to run with Python 3.8, 3.9, 3.10, 3.11.
- Modified to only run after pypi publish.