### PR TITLE
Make scipy installs more deterministic

### DIFF
--- a/.github/workflows/pytest-unit-tests.yml
+++ b/.github/workflows/pytest-unit-tests.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Test with pytest
         working-directory: tests
         run: |
-          sudo apt install libopenblas-dev # scipy
+          sudo apt-get update
+          sudo apt-get install libopenblas-dev # scipy
           pip install -r requirements.txt
           pytest .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 music21==8.1.0
-scipy==1.13.0
+scipy==1.10.1; python_version < '3.9'
+scipy==1.13.0; python_version >= '3.9'


### PR DESCRIPTION
Fixes scipy version to 1.10.1 for python 3.8 and lower. Adds apt-get update before apt-get to avoid failures.